### PR TITLE
Adding analytics support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,22 @@
     <link href='css/style.css' rel='stylesheet' />
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet">
 
+    <!-- Matomo -->
+    <script type="text/javascript">
+      var _paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+            var u="//analytics.softwarefreedom.in/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '1']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+          })();
+    </script>
+    <!-- End Matomo Code -->
+
 
 </head>
 <body>


### PR DESCRIPTION
Adding analytics support. 
The analytics is powered by Matomo. 
We run a self hosted instance. 
All page visitor IP addresses are anonymized by default. 